### PR TITLE
Changed quality parameter from -q to -qscale in order to work with Libav 0.8.6

### DIFF
--- a/lib/AudioFormat.php
+++ b/lib/AudioFormat.php
@@ -40,7 +40,7 @@
 			));
 			$this->_format_to_command = array_merge($this->_format_to_command, array(
 				'disable_audio' 			=> '-an',
-				'audio_quality' 			=> '-q:a <setting>',
+				'audio_quality' 			=> '-qscale:a <setting>',
 				'audio_codec' 				=> '-acodec <setting>',
 				'audio_bitrate' 			=> '-ab <setting>',
 				'audio_sample_frequency' 	=> '-ar <setting>',

--- a/lib/Format.php
+++ b/lib/Format.php
@@ -49,7 +49,7 @@
 				'threads' => null,
 			);
 			$this->_format_to_command = array(
-				'quality' => '-q <setting>',
+				'quality' => '-qscale <setting>',
 				'format'  => '-f <setting>',
 				'strictness'  => '-strict <setting>',
 				'preset_options_file'  => '-fpre <setting>',

--- a/lib/VideoFormat.php
+++ b/lib/VideoFormat.php
@@ -79,7 +79,7 @@
 			));
 			$this->_format_to_command = array_merge($this->_format_to_command, array(
 				'disable_video' 			=> '-vn',
-				'video_quality' 			=> '-q:v <setting>',
+				'video_quality' 			=> '-qscale:v <setting>',
 				'video_codec' 				=> '-vcodec <setting>',
 				'video_dimensions' 			=> '-s <width>x<height>',
 				'video_scale' 				=> '-vf scale=<width>:<height>',


### PR DESCRIPTION
We encountered some problems on a fresh installed Debian machine and Libav.
The parameter -q wasn't recognized by Libav tools and we had to change it to the long -qscale.
This just works with FFMpeg too.
