### PR TITLE
Adds output of files container-format

### DIFF
--- a/src/PHPVideoToolkit/MediaParser.php
+++ b/src/PHPVideoToolkit/MediaParser.php
@@ -682,10 +682,10 @@
             $raw_data = $this->getFileRawInformation($file_path, $read_from_cache);
 
 //          match the audio stream info
-            $data = false;
+            $data = '';
             if(preg_match('/Input #0, ([^\s]+), from/', $raw_data, $matches) > 0)
             {
-                $data = true;
+                $data = $matches[1];
             }
 
             $this->_cacheSet($cache_key, $data);


### PR DESCRIPTION
This adds a new array-entry to the fileInformation-array that contains
the container-format of the file.

This has been testet with ffmpeg (version 1.2.4) and avconv (version
0.8.6-6:0.8.6-1)
