### PR TITLE
bugfix with mp3 codec choose

### DIFF
--- a/src/PHPVideoToolkit/AudioFormat.php
+++ b/src/PHPVideoToolkit/AudioFormat.php
@@ -152,7 +152,7 @@
 //          updated. thanks to Varon for providing the research
             if(in_array($audio_codec, array('mp3', 'libmp3lame')) === true)
             {
-                $audio_codec = isset($codecs['libmp3lame']) === true ? 'libmp3lame' : 'mp3';
+                $audio_codec = in_array('libmp3lame',$codecs) ? 'libmp3lame' : 'mp3';
             }
 //          fix vorbis
             else if($audio_codec === 'vorbis' || $audio_codec === 'libvorbis' )


### PR DESCRIPTION
Was wrong choose of "mp3" when "libmp3lame" available.

$codecs = array_keys($this->getCodecs('audio'));
//.... now $codecs is array of names, not name=>value, so rihgt way to check is:
$audio_codec = in_array('libmp3lame',$codecs) ? 'libmp3lame' : 'mp3';
