### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
-#[2.2.0-beta] [10.04.2014]
+# [2.2.0-beta] [10.04.2014]
 WARNING: Potential code breaking changes across the board. Please do not upgrade existing stable scripts to this codebase. Please use 2.1.5 or below for stability.
 - merged in multi-output branch so that the master branch now supports multi output from ffmpeg.
 - fixed far too many other bugs to mention.
 
-#[2.1.7-beta] [09.04.2014]
+# [2.1.7-beta] [09.04.2014]
 WARNING: Potential code breaking change from Media->save. save() no longer returns the output path if saved in blocking mode. It returns as non-blocking mode does the FfmpegProcess object. So to return the output path of what has been outputed you must call $process->getOutput(). Please use 2.1.5 or below for stability.
 Fixed several bugs:
 - fixed issues in portability progress handler where parsing of image only output data would fail.
@@ -11,41 +11,41 @@ Fixed several bugs:
 - fixed issues where using %timecode or %index in the output would not correctly get renamed unless calling getOutput from the process object. #22
 - fixed issues with animated gifs not following the overwrite setting of the save function call
 
-#[2.1.6-beta] [08.04.2014]
+# [2.1.6-beta] [08.04.2014]
 By default image rotation does not automatically modify the aspect ratio settings of rotated output, however this patch fixes that. If an aspect ratio is not already set and a rotation means that the aspect ratio is not the same as the current ratio then a new ratio will be applied.
 This patch also provides automated functionality where if the aspect ratio does not match the width and height, the ratio corrected width and height and height are returned instead of the actual width and height. This will mean that any output processed from a mis matching file will be as expected.
 Relates to issue #22.
 Marked as beta as it may have unintended consequences that could result in errors.
 
-#[2.1.5] [31.03.2014]
+# [2.1.5] [31.03.2014]
 Replaced _run recursive call with a while loop.
 Provides exactly the same functionality with the benefits of no longer gradually increasing memory usage of the PHP process while transcoding. No longer trips up on xdebug.max_nesting_level setting.
 Thanks petewatts.
 
-#[2.1.4] [19.03.2014]
+# [2.1.4] [19.03.2014]
 Bug fix point release. The AudioFormat class was incorrectly checking a comparison via isset rather than in_array. This fixes that problem and potentially any issues you may have had with mp3/vorbis audio encoding.
 
-#[2.1.3] [17.03.2014]
+# [2.1.3] [17.03.2014]
 A bug fix point release for systems when realpath returns false on some systems and thus the configsetexceptions thrown have no path set in the message.
 If you already successfully have PHPVideoToolkit installed or are on a system where realpath returns the directory regardless of whether it exists or not then you can skip this version.
 
-#[2.1.2] [20.02.2014]
+# [2.1.2] [20.02.2014]
 	- Fixes for missing protected config variable
 
-#[2.1.1-dev] [31.01.2014]
+# [2.1.1-dev] [31.01.2014]
 	- Updates to examples and minor fixes to missing probe data
 
-#[2.1.0] [30.01.2014]
+# [2.1.0] [30.01.2014]
 	- Added ProgressHandlerPortable to provide portable accessibility to encoding 
 	  progress information
 
-#[2.0.0] [22.11.2013]
+# [2.0.0] [22.11.2013]
 		- Fixed various bugs
 
-#[2.0.0] [25.03.2013]
+# [2.0.0] [25.03.2013]
 		- Updated codebase to v2. Main repo is now on github https://github.com/buggedcom/phpvideotoolkit-v2
 
-#[0.1.5] [06.06.2008] 
+# [0.1.5] [06.06.2008] 
 	- REMOVED dependancy on buffering the exec calls to a file, parsing the file and
 	  then unlinking the file. Cuts down considerably of the impact of the class on
 	  the server. Thanks Varon. http://www.buggedcom.co.uk/discuss/viewtopic.php?id=10
@@ -60,7 +60,7 @@ If you already successfully have PHPVideoToolkit installed or are on a system wh
 	  distributed under a BSD License. The full package can be downloaded from:
 	  http://sourceforge.net/project/showfiles.php?group_id=223120
 
-#[0.1.4] [10.04.2008] 
+# [0.1.4] [10.04.2008] 
 	- ADDED phpvideotoolkit.php4.php and renamed the php5 class 
 	  phpvideotoolkit.php5.php, however the adapter classes will remain php5 only
 	  for the time being. Allow the adapters are php5 it would be very simple for
@@ -79,7 +79,7 @@ If you already successfully have PHPVideoToolkit installed or are on a system wh
 	  incompatible with the BSD license. Now integrated with php-reader 
 	  http://code.google.com/p/php-reader/ which is licensed under a New BSD license.
 
-#[0.1.3] [04.04.2008] 
+# [0.1.3] [04.04.2008] 
 	- RENAMED primary class to PHPVideoToolkit to avoid any confusion with 
 	  ffmpeg-php
 	- THANKS to Istvan Szakacs, and Rob Coenen for providing some valuable feedback, 
@@ -121,7 +121,7 @@ If you already successfully have PHPVideoToolkit installed or are on a system wh
 	- CHANGED the functionality of example04.php to show usage of addGDWatermark
 	  if vhooking is not enabled.
 	
-#[0.1.2] [03.04.2008] 
+# [0.1.2] [03.04.2008] 
 	- FIXED bug in PHPVideoToolkit::getFileInfo() that in some instances didn't return 
 	  the correct information, such as dimensions and frame rate. Thanks to
 	  Istvan Szakacs for pointing out the error.
@@ -158,7 +158,7 @@ If you already successfully have PHPVideoToolkit installed or are on a system wh
 	- UPDATED PHPVideoToolkit::_combineCommands so commands can be ordered in the exec
 	  string.
 
-#[0.1.1] [29.03.2008] 
+# [0.1.1] [29.03.2008] 
 	- FIXED bug in the post processing of exporting a series of image frames.
 	  With thanks to Rob Coenen.
 	- FIXED bug in PHPVideoToolkit::getFileInfo() that returned the incorrect frame
@@ -187,7 +187,7 @@ If you already successfully have PHPVideoToolkit installed or are on a system wh
 	  to be generated more than one in the same script it only gets generated 
 	  once.
 
-#[0.1.0] [02.03.2008] 
+# [0.1.0] [02.03.2008] 
 	- ADDED new constant PHPVideoToolkit::SIZE_SAS. Which stands for Same As Source,  
 	  meaning ffmpeg will automatically convert the movie to a whatever format   
 	  but preserve the size of the original movie.
@@ -242,7 +242,7 @@ If you already successfully have PHPVideoToolkit installed or are on a system wh
 	  translation/changes.
 	- CHANGED moveLog functionality to use rename instead of copy and unlink.
 
-#[0.0.9] [12.02.2008] 
+# [0.0.9] [12.02.2008] 
 	- Added new definition FFMPEG_MENCODER_BINARY to point to the mencoder 
 	  binary.
 	- Changed the behavior of setVideoOutputDimensions. it now accepts class
@@ -269,7 +269,7 @@ If you already successfully have PHPVideoToolkit installed or are on a system wh
 	- Fixed bug in setFormat error message.
 	- Fixed bug in execute.
 
-#[0.0.8] [07.08.2007] 
+# [0.0.8] [07.08.2007] 
 	- Added public functions secondsToTimecode & timecodeToSeconds. Translates
 	  seconds into a timecode and visa versa.
 	  ie. 82 => 00:01:22 & 00:01:22 => 82
@@ -277,7 +277,7 @@ If you already successfully have PHPVideoToolkit installed or are on a system wh
 	  frames are re-stamped with the frames timecode if true.
 	- Fixed bug in setOutput.
 
-#[0.0.7] [01.08.2007] 
+# [0.0.7] [01.08.2007] 
 	- Added FFMPEG_FORMAT_Y4MP format (yuv4mpegpipe).
 	- Added extra information to install.txt
 	- Added public function hasCommand.
@@ -289,7 +289,7 @@ If you already successfully have PHPVideoToolkit installed or are on a system wh
 	  image extension then and no %d is found then an error is raised.
 	- Changed all booleans from upper to lower case.
 	
-#[0.0.5] [12.03.2007] 
+# [0.0.5] [12.03.2007] 
 	- Added FFMPEG_FORMAT_JPG format (mjpeg). Thanks Matthias.
 	- Changed the behavior of extractFrames. It now accepts a boolean FALSE
 	  argument for $extract_end_timecode. 
@@ -301,5 +301,5 @@ If you already successfully have PHPVideoToolkit installed or are on a system wh
 	  makes specific useage of vhook. If your ffmpeg binary has not been
 	  compiled with --enable-vhook then this will not work.
 	
-#[0.0.1] [02.03.2007] 
+# [0.0.1] [02.03.2007] 
 	- Initial version released

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,15 +1,15 @@
 PHPVideoToolkit Copyright (c) 2013 Oliver Lillie <http://www.buggedcom.co.uk>
 
-#DUAL Licensed under MIT and GPL v2
+# DUAL Licensed under MIT and GPL v2
 
-##MIT
+## MIT
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-##GPL v2
+## GPL v2
 
 Copyright (C) 1989, 1991 Free Software Foundation, Inc. 
 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#PHPVideoToolkit V2...
+# PHPVideoToolkit V2...
 
 ...is a set of PHP classes aimed to provide a modular, object oriented and accessible interface for interacting with videos and audio through FFmpeg.
 
@@ -6,7 +6,7 @@ PHPVideoToolkit also provides FFmpeg-PHP emulation in pure PHP so you wouldn't n
 
 **IMPORTANT** PHPVideoToolkit has only been tested with v1.1.2 of FFmpeg. Whilst the majority of functionality should work regardless of your version of FFmpeg I cannot guarantee it. If you find a bug or have a patch please open a ticket or submit a pull request on https://github.com/buggedcom/phpvideotoolkit-v2
 
-###Table of Contents
+### Table of Contents
 
 - [License](#license)
 - [Documentation](#documentation)
@@ -39,7 +39,7 @@ PHPVideoToolkit also provides FFmpeg-PHP emulation in pure PHP so you wouldn't n
 - [Imposing a processing time limit](#imposing-a-processing-time-limit)
 - [Forcing a specific output format whilst using a silly file extension](#forcing-a-specific-output-format-whilst-using-a-silly-file-extension)
 
-##License
+## License
 
 PHPVideoToolkit Copyright (c) 2008-2014 Oliver Lillie
 
@@ -47,11 +47,11 @@ DUAL Licensed under MIT and GPL v2
 
 See LICENSE.md for more details.
 
-##Documentation
+## Documentation
 
 Extensive documentation and examples are bundled with the download and is available in the documentation directory.
 
-##Latest Changes
+## Latest Changes
 
 **[2.2.0-beta]** [10.04.2014]
 
@@ -61,11 +61,11 @@ WARNING: Potential code breaking changes across the board. Please do not upgrade
 
 [Full changelog](https://github.com/buggedcom/phpvideotoolkit-v2/blob/master/CHANGELOG.md)
 
-##Usage
+## Usage
 
 Whilst the extensive documentation covers just about everything (to be honest there are only a few pages in the documentation as I'm too busy to write too much of it - but the examples below are pretty good), here are a few examples of what you can do.
 
-###Configuring PHPVideoToolkit
+### Configuring PHPVideoToolkit
 
 PHPVideoToolkit requires some basic configuration and is one through the Config class. The Config class is then used in the constructor of most PHPVideoToolkit classes. Any child object initialised within an already configured class will inherit the configuration options of the parent.
 
@@ -85,7 +85,7 @@ $config = new Config(array(
 Take special note of the second parameter ```true```. If set as true then the related Config object is set as the default config instance. This means that once set as the default instance you do not need to supply the Config object to the other PHPVideoToolkit class constructors. If a config object is not defined and supplied to the PHPVideoToolkit classes, then a default Config object is created and assigned to the class.
 
 Every example below assumes that the Config object has been set as the default config object prior in the execution so there is no need to supply config to each example.
-###Accessing Data About FFmpeg
+### Accessing Data About FFmpeg
 
 Simple demonstration about how to access information about FfmpegParser object.
 
@@ -97,7 +97,7 @@ $is_available = $ffmpeg->isAvailable(); // returns boolean
 $ffmpeg_version = $ffmpeg->getVersion(); // outputs something like - array('version'=>1.0, 'build'=>null)
 	
 ```
-###Accessing Data About media files
+### Accessing Data About media files
 
 Simple demonstration about how to access information about media files using the MediaParser object.
 
@@ -109,7 +109,7 @@ $data = $parser->getFileInformation('BigBuckBunny_320x180.mp4');
 echo '<pre>'.print_r($data, true).'</pre>';
 	
 ```
-###PHPVideoToolkit Timecodes
+### PHPVideoToolkit Timecodes
 PHPVideoToolkit utilises Timecode objects when extracting data such as duration or start points, or when extracting portions of a media file. They are fairly simple to understand. All of the example timecodes created below are the same time. 
 
 ```php
@@ -148,7 +148,7 @@ echo $timecode->seconds; // Outputs 39
 
 It's very important to note, as in the last example, that there is a massive difference between accessing ```$timecode->seconds``` and ```$timecode->total_seconds```. `seconds` is the number of seconds in the remaining minute of the timecode. `total_seconds` is the total number of seconds of the timecode. The same logic applies to minutes, hours, milliseconds and their total_ prefixed counterparts.
 
-###PHPVideoToolkit Output Formats
+### PHPVideoToolkit Output Formats
 
 PHPVideoToolkit contains a base class `Format`. This class is extended by three other important base classes called `AudioFormat`, `VideoFormat` and `ImageFormat`. They extend as follows: Format > AudioFormat > VideoFormat > ImageFormat. This allows each of the later formats to inherit functionality from the previous format.
 
@@ -244,7 +244,7 @@ $video->save('output.mp4', $output_format);
 ```
 
 
-###Forcing a specific output format whilst using a silly file extension
+### Forcing a specific output format whilst using a silly file extension
 
 Because of the advanced nature of the input and output formatters, if supplied you can encode a specific output, but use a silly (or custom) file extension. Not really sure why you would want to but it is possible.
 
@@ -256,7 +256,7 @@ $video->save('output.my_silly_custom_file_extension', new ImageFormat_Jpeg());
 				
 ```
 
-###Extract a Single Frame of a Video
+### Extract a Single Frame of a Video
 
 The code below extracts a frame from the video at the 40 second mark.
 
@@ -268,7 +268,7 @@ $process = $video->extractFrame(new Timecode(40))
 				->save('./output/big_buck_bunny_frame.jpg');
 $output = $process->getOutput();
 ```
-###Extract Multiple Frames from a Segment of a Video
+### Extract Multiple Frames from a Segment of a Video
 
 The code below extracts frames at the parent videos' frame rate from between 40 and 50 seconds. If the parent video has a frame rate of 24 fps then 240 images would be extracted from this code.
 
@@ -281,7 +281,7 @@ $process = $video->extractFrames(new Timecode(40), new Timecode(50))
 $output = $process->getOutput();
 ```
 
-###Extract Multiple Frames of a Video at 1 frame per second
+### Extract Multiple Frames of a Video at 1 frame per second
 
 There are two ways you can export at a differing frame rate from that of the parent video. The first is to use an output format to set the video frame rate.
 
@@ -320,7 +320,7 @@ $process = $video->extractFrames(new Timecode(50), null, 1) // if null then the 
 $output = $process->getOutput();
 ```
 
-###Extract Multiple Frames of a Video at 1 frame every 'x' seconds
+### Extract Multiple Frames of a Video at 1 frame every 'x' seconds
 
 The code below uses the ```$force_frame_rate``` argument for ```$video->extractFrames()```, however the same 1/n notation can be used on ```$video_format->setFrameRate()```. This example will output 1 frame every 60 seconds of video.
 
@@ -333,7 +333,7 @@ $process = $video->extractFrames(new Timecode(40), new Timecode(50), '1/60')
 $output = $process->getOutput();
 ```
 
-###Caveats of Extracting Multiple Frames
+### Caveats of Extracting Multiple Frames
 
 ***IMPORTANT:*** It is important to note that if you exporting multiple frames a video you will not always get the expected amount of frames you would expect. This is down to the way FFmpeg treats timecodes. Take the example below into consideration.
 
@@ -363,7 +363,7 @@ while(current < end)
 
 So if we require 10 frames you must actually set your end timecode to a little over 20 seconds like so ```$video->extractSegment(new \PHPVideoToolkit\Timecode(10), new \PHPVideoToolkit\Timecode(20.1))```
 
-###Combining Multiple Images and Audio to form a Video
+### Combining Multiple Images and Audio to form a Video
 
 Whilst PHPVideoToolkit does not natively support combing multiple images and audio into a video, it can still be achieved by add custom commands to the process object.
 
@@ -385,7 +385,7 @@ $process = $audio->save('./output/my_homemade_video.mp4', $output_format, Media:
 
 ```
 
-###Extracting an Animated Gif
+### Extracting an Animated Gif
 Now, FFmpeg's animated gif support is a pile of doggy do do. I can't understand why. However what PHPVideoToolkit does is bypass the native gif exporting of FFmpeg and provide it's own much better alternative.
 
 There are several options available to you when exporting an animated gif. You can use Gifsicle, Imagemagicks convert, or native PHP GD with the symbio/gif-creator composer library.
@@ -474,7 +474,7 @@ $process = $video->extractSegment(new Timecode(10), new Timecode(20))
 $output = $process->getOutput();
 ```
 
-###Resizing Video and Images
+### Resizing Video and Images
 
 In order to resize output video and imagery output you need to supply an [output format](#phpvideotoolkit-output-formats) to the save function you call. The below snippet is an example of resizing a video, however you would use same function call to `setVideoDimensions` just instead of a `VideoFormat` object you would use an `ImageFormat` object.
 
@@ -491,7 +491,7 @@ $video->save('BigBuckBunny_160x120.3gp', $output_format);
 
 ```
 
-###Extracting Audio or Video Channels from a Video
+### Extracting Audio or Video Channels from a Video
 
 ```php
 namespace PHPVideoToolkit;
@@ -503,7 +503,7 @@ $process = $video->extractAudio()->save('./output/big_buck_bunny.mp3');
 $output = $process->getOutput();
 ```
 
-###Extracting a Segment of an Audio or Video file
+### Extracting a Segment of an Audio or Video file
 
 The code below extracts a portion of the video at the from 2 minutes 22 seconds to 3 minutes (ie 180 seconds). *Note the different settings for constructing a timecode.* The timecode object can accept different formats to create a timecode from.
 
@@ -515,7 +515,7 @@ $process = $video->extractSegment(new Timecode('00:02:22.0', Timecode::INPUT_FOR
 				->save('./output/big_buck_bunny.mp4');
 $output = $process->getOutput();
 ```
-###Splitting a Audio or Video file into multiple parts
+### Splitting a Audio or Video file into multiple parts
 
 There are multiple ways you can configure the split parameters. If an array is supplied as the first argument. It must be an array of either, all Timecode instances detailing the timecodes at which you wish to split the media, or all integers. If integers are supplied the integers are treated as frame numbers you wish to split at. You can however also split at even intervals by suppling a single integer as the first parameter. That integer is treated as the number of seconds that you wish to split at. If you have a video that is 3 minutes 30 seconds long and set the split to 60 seconds, you will get 4 videos. The first three will be 60 seconds in length and the last would be 30 seconds in length.
 
@@ -529,7 +529,7 @@ $process = $video->split(45)
 				->save('./output/big_buck_bunny_%timecode.mp4');
 $output = $process->getOutput();
 ```
-###Purging and then adding Meta Data
+### Purging and then adding Meta Data
 
 Unfortunately there is no way using FFmpeg to add meta data without re-encoding the file. There are other tools that can do that though, however if you wish to write meta data to the media during encoding you can do so using code like the example below.
 
@@ -542,7 +542,7 @@ $process = $video->purgeMetaData()
 				->save('./output/big_buck_bunny.mp4');
 $output = $process->getOutput();
 ```
-###Changing Codecs of the audio or video stream
+### Changing Codecs of the audio or video stream
 
 By default PHPVideoToolkit uses the file extension of the output file to automatically generate the required ffmpeg settings (if any) of your desired file format. However if you want to specify different codecs or settings, it is ncessesary to specify them within an output format container. There are three different format objects you can use, depending on the format of your output. They are AudioFormat, VideoFormat and ImageFormat.
 
@@ -577,7 +577,7 @@ $process = $video->save($output_path, $output_format);
 
 $output = $process->getOutput();
 ```
-###Non-Blocking Saves
+### Non-Blocking Saves
 
 The default/main save() function blocks PHP until the encoding process has completed. This means that depending on the size of the media you are encoding it could leave your script running for a long time. To combat this you can call saveNonBlocking() to start the encoding process without blocking PHP.
 
@@ -614,7 +614,7 @@ else
 
 ```
 
-###Encoding with Progress Handlers
+### Encoding with Progress Handlers
 
 Whilst the code above from Non-Blocking Saves looks like it is a progress handler (and it is in a sense, but it doesn't provide data on the encode), progress handlers provide much more detailed information about the current encoding process.
 
@@ -723,7 +723,7 @@ exit;
 
 **2**: When outputting files using %timecode or %index and using the ProgressHandlerPortable system it is not possible to currently automatically renaming the resulting temporary file output to their correct output filenames.
 
-###Information Available to the Progress Handlers
+### Information Available to the Progress Handlers
 All of the progress handlers outlined above returned the same information, albeit there are some minor differences as when some of the data is available, however the difference is negligle and for the purposes of this document they really do not matter. Below is a sample output of the data available from ```$progress_handler->probe();```
 
 ```
@@ -892,7 +892,7 @@ This value is either a) a path value as a string if the above 'input_count' is 1
 
 This is a path string pointing to the current process file that the progress handler is using to read the data from.
 
-###Encoding Multiple Output Files
+### Encoding Multiple Output Files
 
 FFmpeg allows you to [encode multiple output formats from a single command](https://trac.ffmpeg.org/wiki/Creating%20multiple%20outputs). PHPVideoToolkit allows you to perform this functionality as well. This functionality is essentially the same process as performing multiple saves, however has the added benefit of lower overhead because the input file only has to be read into memory once before the encoding takes place. It is recommended that you use this method if you are outputting more than one version of the media. There are of course several caveats when using this method however. 
 
@@ -923,7 +923,7 @@ All progress handlers also work with multiple output, however the caveats outlin
 
 **IMPORTANT** Whilst this is technically possibly, depending on your server and the number of outputs you are generating, it can be quicker to simply chain the requests together instead. See the [chaining processes example](https://github.com/buggedcom/phpvideotoolkit-v2/blob/master/examples/chaining-processes.php) for more information on method chaining.
 
-###Accessing Executed Commands and the Command Line Buffer
+### Accessing Executed Commands and the Command Line Buffer
 
 There may be instances where things go wrong and PHPVideoToolkit hasn't correctly prevented or reported any encoding/decoding errors, or, you may just want to log what is going on. You can access any executed commands and the command lines output fairly simply as the example below shows.
 
@@ -952,7 +952,7 @@ echo 'Actual Command Line Buffer<br />';
 echo '<pre>'.$process->getRawBuffer().'</pre>';
 ```
 
-###Supplying custom commands
+### Supplying custom commands
 
 Because FFmpeg has a specific order in which certain commands need to be added there are a few functions you should be aware of. First of the code below shows you how to access the code FfmpegProcess object. The process object is itself a wrapper around the ProcessBuilder (helps to build queries) and ExceBuffer (executes and controls the query) objects.
 
@@ -999,7 +999,7 @@ HOWEVER, there is an important caveat you need to be aware of, the above command
 ((/opt/local/bin/ffmpeg '-custom-command' '-i' '/your/input/file.mp4' '-custom-command-with-arg' 'arg value' '-y' '-qscale' '4' '-f' 'mp4' '-strict' 'experimental' '-threads' '1' '-acodec' 'mp3' '-vcodec' 'h264' '/your/output/file.mp4' '-output-command' 'another value' && echo '<c-219970-52ea5f8c9ca9d-da39f7c51d495967dfec435dc91e2879>') || echo '<f-219970-52ea5f8c9ca9d-da39f7c51d495967dfec435dc91e2879>' '<c-219970-52ea5f8c9ca9d-da39f7c51d495967dfec435dc91e2879>' '<e-219970-52ea5f8c9ca9d-da39f7c51d495967dfec435dc91e2879>'$?) 2>&1 > '/tmp/phpvideotoolkit_lvsukB' 2>&1 &
 ```
 
-###Imposing a processing timelimit
+### Imposing a processing timelimit
 
 You may wish to impose a processing timelimit on encoding. There are various reasons for doing this and should be self explanatory. FFmpeg supplies a command to be able to do this and can be invoked like so...
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
